### PR TITLE
Add Bucketization Methods for Light and Precise structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 siphasher = "0.3.10"
 num-traits = "0.2"
 ordered-float = "3.6.0"
+buckets = { git = "https://github.com/vrrb-io/buckets", branch = "main" }

--- a/src/cms_iter.rs
+++ b/src/cms_iter.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::ops::{AddAssign, SubAssign, Add, DivAssign};
 use std::hash::Hash;
 use num_traits::Bounded;
@@ -21,6 +22,7 @@ where
     + Add<Output = T>
     + Hash
     + Ord 
+    + Debug 
     + Bounded
 {
     pub cms: &'a CountMinSketch<T>,
@@ -43,6 +45,7 @@ where
     + DivAssign
     + Hash 
     + Ord 
+    + Debug 
     + Bounded
 {
     pub matrix: Vec<Vec<T>>,
@@ -60,6 +63,7 @@ where
     + Add<Output = T>
     + Hash 
     + Ord 
+    + Debug 
     + Bounded
 {
     type Item = &'a T;
@@ -91,6 +95,7 @@ where
     + Add<Output = T>
     + Hash 
     + Ord 
+    + Debug 
     + Bounded
 {
     type Item = &'a T;
@@ -114,6 +119,7 @@ where
     + Clone 
     + Hash 
     + Ord
+    + Debug 
     + Bounded
 {
     type Item = T;
@@ -148,6 +154,7 @@ where
     + Clone
     + Hash 
     + Ord 
+    + Debug 
     + Bounded
 {
     type Item = T;

--- a/src/honest_peer.rs
+++ b/src/honest_peer.rs
@@ -24,6 +24,7 @@ pub trait HonestPeer {
         + Mul<Output = Self::Value> 
         + Div<Output = Self::Value> 
         + Sub<Output = Self::Value> 
+        + PartialOrd
         + Copy 
         + Default 
         + Bounded; 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,13 @@ pub mod honest_peer;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::probabilistic::LightHonestPeer;
+    use crate::honest_peer::HonestPeer;
+    use buckets::bucketizers::{fw::FixedWidthBucketizer, range::RangeBucketizer};
+    use buckets::bucketize::BucketizeSingle;
+    use ordered_float::OrderedFloat;
+    use num_traits::Bounded;
+    
 
     #[test]
     fn should_create_precise_honest_peer_instance() {}
@@ -71,4 +78,67 @@ mod tests {
     #[test]
     fn should_get_nodes_reputation_score_precise() {}
 
+    #[test]
+    fn should_bucketize_estimates() {
+
+        let mut hp: LightHonestPeer<String, OrderedFloat<f64>> = {
+            LightHonestPeer::new_from_bounds(
+                1f64,
+                0.0001f64,
+                3000f64,
+                OrderedFloat::<f64>::min_value(),
+                OrderedFloat::<f64>::max_value()
+            )
+        };
+
+        let node_ids = vec!["node_1".to_string(), "node_2".to_string(), "abcde".to_string()];
+        let ranges: Vec<(OrderedFloat<f64>, OrderedFloat<f64>)> = vec![
+            (OrderedFloat::from(0.0), OrderedFloat::from(5.0)),
+            (OrderedFloat::from(5.0), OrderedFloat::from(15.0)), 
+            (OrderedFloat::from(15.0), OrderedFloat::from(30.0)),
+            (OrderedFloat::from(30.0), OrderedFloat::<f64>::max_value())
+        ];
+
+        let bucketizer = RangeBucketizer::new(ranges); 
+
+        hp.update_local(&"node_1".to_string(), OrderedFloat::from(7.0));
+        hp.update_local(&"node_2".to_string(), OrderedFloat::from(3.0));
+
+        let mut map = hp.bucketize_local(node_ids.iter().cloned(), bucketizer);
+
+        assert_eq!(Some(("node_1".to_string(), 1)), map.next());
+        assert_eq!(Some(("node_2".to_string(), 0)), map.next());
+        assert_eq!(Some(("abcde".to_string(), 0)), map.next());
+
+    }
+
+    #[test]
+    fn should_bucketize_normalized_estimates() {
+        let mut hp: LightHonestPeer<String, OrderedFloat<f64>> = {
+            LightHonestPeer::new_from_bounds(
+                1f64,
+                0.0001f64,
+                3000f64,
+                OrderedFloat::<f64>::min_value(),
+                OrderedFloat::<f64>::max_value()
+            )
+        };
+    
+        let node_ids = vec!["node_1".to_string(), "node_2".to_string(), "abcde".to_string()];
+    
+        let bucketizer: FixedWidthBucketizer<OrderedFloat<f64>> = {
+            FixedWidthBucketizer::<OrderedFloat<f64>>::new(
+                OrderedFloat::from(0.05), OrderedFloat::from(0.0)
+            ) 
+        };
+    
+        hp.update_local(&"node_1".to_string(), OrderedFloat::from(7.0));
+        hp.update_local(&"node_2".to_string(), OrderedFloat::from(3.0));
+
+        let mut map = hp.bucketize_normalized_local(node_ids.iter().cloned(), bucketizer);
+    
+        assert_eq!(Some(("node_1".to_string(), 13)), map.next());
+        assert_eq!(Some(("node_2".to_string(), 5)), map.next());
+        assert_eq!(Some(("abcde".to_string(), 0)), map.next());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,69 @@ pub mod honest_peer;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn should_create_precise_honest_peer_instance() {}
+    
+    #[test]
+    fn should_create_light_honest_peer_instance() {}
+
+    #[test]
+    fn should_create_count_min_sketch_instance() {}
+
+    #[test]
+    fn should_increment_count_min_sketch_estimate() {}
+
+    #[test]
+    fn should_decrement_count_min_sketch_estimate() {}
+
+    #[test]
+    fn should_increment_node_reputation_in_precise_instance() {}
+
+    #[test]
+    fn should_decrement_node_reputation_in_precise_instance() {}
+
+    #[test]
+    fn should_increment_node_reputation_in_light_instance() {}
+
+    #[test]
+    fn should_decrement_node_reputation_in_light_instance() {}
+
+    #[test]
+    fn increment_should_be_weighted_by_sender_local_reputation_precise() {}
+
+    #[test]
+    fn decrement_should_be_weighted_by_sender_local_reputation_precise() {}
+
+    #[test]
+    fn increment_should_be_weighted_by_sender_local_reputation_light() {}
+
+    #[test]
+    fn decrement_should_be_weighted_by_sender_local_reputation_light() {}
+
+    #[test]
+    fn increments_should_be_normalized_in_normalized_local_map_precise() {}
+
+    #[test]
+    fn decrements_should_be_normalized_in_normalized_global_map_precise() {}
+    
+    #[test]
+    fn increments_should_be_normalized_in_normalized_local_map_light() {}
+
+    #[test]
+    fn decrements_should_be_normalized_in_normalized_global_map_light() {}
+
+    #[test]
+    fn reputation_estimates_should_not_exceed_bounds_light() {}
+
+    #[test]
+    fn reputation_scores_should_be_precise_in_precise() {}
+
+    #[test]
+    fn reputation_estimates_should_maintain_insertion_order_light() {}
+
+    #[test]
+    fn should_get_nodes_reputation_score_precise() {}
 
 }

--- a/src/probabilistic.rs
+++ b/src/probabilistic.rs
@@ -1,8 +1,8 @@
 use std::hash::Hash;
 use std::ops::{AddAssign, DivAssign, SubAssign, Add, Mul, Div, Sub};
+use buckets::bucketize::BucketizeSingle;
 use num_traits::Bounded;
 use std::marker::PhantomData;
-
 use crate::cms::CountMinSketch;
 use crate::honest_peer::HonestPeer;
 
@@ -148,6 +148,70 @@ where
             normalized_global_trust: sketch.clone(),
             id_type: None
         }
+    }
+
+    pub fn bucketize_local<'a, B>(
+        &'a self, 
+        node_ids: impl Iterator<Item = K> + 'a, 
+        bucketizer: B
+    ) -> impl Iterator<Item = (K, usize)> + '_
+    where 
+        B: BucketizeSingle<V> + 'a
+    {
+        node_ids.map(move |k| {
+            let estimate = self.local_trust.estimate(&k);
+            let bucketed = bucketizer.bucketize(&estimate);
+            (k, bucketed)
+
+        })
+    }
+
+    pub fn bucketize_normalized_local<'a, B>(
+        &'a self, 
+        node_ids: impl Iterator<Item = K> + 'a, 
+        bucketizer: B
+    ) -> impl Iterator<Item = (K, usize)> + '_
+    where 
+        B: BucketizeSingle<V> + 'a
+    {
+        node_ids.map(move |k| {
+            let estimate = self.normalized_local_trust.estimate(&k);
+            let bucketed = bucketizer.bucketize(&estimate);
+            (k, bucketed)
+
+        })
+    }
+
+    pub fn bucketize_global<'a, B>(
+        &'a self, 
+        node_ids: impl Iterator<Item = K> + 'a, 
+        bucketizer: B
+    ) -> impl Iterator<Item = (K, usize)> + '_
+    where 
+        B: BucketizeSingle<V> + 'a
+    {
+        node_ids.map(move |k| {
+            let estimate = self.global_trust.estimate(&k);
+            let bucketed = bucketizer.bucketize(&estimate);
+            (k, bucketed)
+
+        })
+    }
+
+    pub fn bucketize_normalized_global<'a, B>(
+        &'a self, 
+        node_ids: impl Iterator<Item = K> + 'a, 
+        bucketizer: B
+    ) -> impl Iterator<Item = (K, usize)> + '_
+    where 
+        B: BucketizeSingle<V> + 'a
+    {
+        node_ids.map(move |k| {
+            let estimate = self.normalized_global_trust.estimate(&k);
+            let bucketed = bucketizer.bucketize(&estimate);
+            (k, bucketed)
+
+        })
     }
 }
 

--- a/src/probabilistic.rs
+++ b/src/probabilistic.rs
@@ -5,6 +5,7 @@ use num_traits::Bounded;
 use std::marker::PhantomData;
 use crate::cms::CountMinSketch;
 use crate::honest_peer::HonestPeer;
+use std::fmt::Debug;
 
 /// A struct to track local and global trust of peers in a 
 /// peer to peer data sharing network. Trust scores 
@@ -19,10 +20,11 @@ use crate::honest_peer::HonestPeer;
 /// use std::marker::PhantomData;
 /// use decentrust::cms::CountMinSketch;
 /// use num_traits::Bounded;
+/// use std::fmt::Debug;
 ///
 /// pub struct LightHonestPeer<K, V> 
 /// where 
-///     K: Eq + Hash + Clone,
+///     K: Eq + Hash + Clone + Debug + ToString,
 ///     V: AddAssign
 ///     + DivAssign
 ///     + SubAssign 
@@ -35,6 +37,7 @@ use crate::honest_peer::HonestPeer;
 ///     + Bounded
 ///     + Ord 
 ///     + Hash
+///     + Debug
 ///
 /// {
 ///     local_trust: CountMinSketch<V>,
@@ -46,7 +49,7 @@ use crate::honest_peer::HonestPeer;
 /// ```
 pub struct LightHonestPeer<K, V> 
 where 
-    K: Eq + Hash + Clone,
+    K: Eq + Hash + Clone + Debug + ToString,
     V: AddAssign 
     + DivAssign 
     + SubAssign 
@@ -59,6 +62,7 @@ where
     + Bounded
     + Ord 
     + Hash
+    + Debug
 {
     local_trust: CountMinSketch<V>,
     global_trust: CountMinSketch<V>,
@@ -70,7 +74,7 @@ where
 
 impl<K, V> LightHonestPeer<K, V> 
 where 
-    K: Eq + Hash + Clone,
+    K: Eq + Hash + Clone + Debug + ToString,
     V: AddAssign 
     + DivAssign 
     + SubAssign 
@@ -83,6 +87,7 @@ where
     + Bounded 
     + Ord 
     + Hash
+    + Debug
 {
     /// Creates a new `LightHonestPeer` struct with no peers in it.
     /// 
@@ -150,6 +155,51 @@ where
         }
     }
 
+    /// Iterates over provided ids, and returns an iterator over 
+    /// (id, usize), i.e. the identifier for each item 
+    /// and the bucketized estimate for that item in the raw local 
+    /// `CountMinSketch`
+    ///
+    /// # Example 
+    ///
+    /// ```
+    ///
+    /// use decentrust::probabilistic::LightHonestPeer;
+    /// use decentrust::honest_peer::HonestPeer;
+    /// use buckets::bucketizers::range::RangeBucketizer;
+    /// use buckets::bucketize::BucketizeSingle;
+    /// use ordered_float::OrderedFloat;
+    /// use num_traits::Bounded;
+    ///
+    /// let mut hp: LightHonestPeer<String, OrderedFloat<f64>> = {
+    ///    LightHonestPeer::new_from_bounds(
+    ///        1f64,
+    ///        0.0001f64,
+    ///        3000f64,
+    ///        OrderedFloat::<f64>::min_value(),
+    ///        OrderedFloat::<f64>::max_value()
+    ///    )
+    /// };
+    ///
+    /// let node_ids = vec!["node_1".to_string(), "node_2".to_string(), "abcde".to_string()];
+    /// let ranges: Vec<(OrderedFloat<f64>, OrderedFloat<f64>)> = vec![
+    ///     (OrderedFloat::from(0.0), OrderedFloat::from(5.0)),
+    ///     (OrderedFloat::from(5.0), OrderedFloat::from(15.0)), 
+    ///     (OrderedFloat::from(15.0), OrderedFloat::from(30.0)),
+    ///     (OrderedFloat::from(30.0), OrderedFloat::<f64>::max_value())
+    /// ];
+    ///
+    /// let bucketizer = RangeBucketizer::new(ranges); 
+    ///
+    /// hp.update_local(&"node_1".to_string(), OrderedFloat::from(7.0));
+    /// hp.update_local(&"node_2".to_string(), OrderedFloat::from(3.0));
+    ///
+    /// let mut map = hp.bucketize_local(node_ids.iter().cloned(), bucketizer);
+    ///
+    /// assert_eq!(Some(("node_1".to_string(), 1)), map.next());
+    /// assert_eq!(Some(("node_2".to_string(), 0)), map.next());
+    /// assert_eq!(Some(("abcde".to_string(), 0)), map.next());
+    /// ```
     pub fn bucketize_local<'a, B>(
         &'a self, 
         node_ids: impl Iterator<Item = K> + 'a, 
@@ -158,7 +208,7 @@ where
     where 
         B: BucketizeSingle<V> + 'a
     {
-        node_ids.map(move |k| {
+       node_ids.map(move |k| {
             let estimate = self.local_trust.estimate(&k);
             let bucketed = bucketizer.bucketize(&estimate);
             (k, bucketed)
@@ -166,6 +216,50 @@ where
         })
     }
 
+    /// Iterates over provided ids, and returns an iterator over 
+    /// (id, usize), i.e. the identifier for each item 
+    /// and the bucketized estimate for that item in the normalized local 
+    /// `CountMinSketch`
+    ///
+    /// # Example 
+    ///
+    /// ```
+    /// use decentrust::probabilistic::LightHonestPeer;
+    /// use decentrust::honest_peer::HonestPeer;
+    /// use buckets::bucketizers::fw::FixedWidthBucketizer;
+    /// use buckets::bucketize::BucketizeSingle;
+    /// use buckets::into_usize::IntoUsize;
+    /// use ordered_float::OrderedFloat;
+    /// use num_traits::Bounded;
+    ///
+    /// let mut hp: LightHonestPeer<String, OrderedFloat<f64>> = {
+    ///    LightHonestPeer::new_from_bounds(
+    ///        1f64,
+    ///        0.0001f64,
+    ///        3000f64,
+    ///        OrderedFloat::<f64>::min_value(),
+    ///        OrderedFloat::<f64>::max_value()
+    ///    )
+    /// };
+    ///
+    /// let node_ids = vec!["node_1".to_string(), "node_2".to_string(), "abcde".to_string()];
+    ///
+    /// let bucketizer: FixedWidthBucketizer<OrderedFloat<f64>> = {
+    ///     FixedWidthBucketizer::<OrderedFloat<f64>>::new(
+    ///         OrderedFloat::from(0.05), OrderedFloat::from(0.0)
+    ///     ) 
+    /// };
+    ///
+    /// hp.update_local(&"node_1".to_string(), OrderedFloat::from(7.0));
+    /// hp.update_local(&"node_2".to_string(), OrderedFloat::from(3.0));
+    ///
+    /// let mut map = hp.bucketize_normalized_local(node_ids.iter().cloned(), bucketizer);
+    ///
+    /// assert_eq!(Some(("node_1".to_string(), 13)), map.next());
+    /// assert_eq!(Some(("node_2".to_string(), 5)), map.next());
+    /// assert_eq!(Some(("abcde".to_string(), 0)), map.next());
+    ///
+    /// ```
     pub fn bucketize_normalized_local<'a, B>(
         &'a self, 
         node_ids: impl Iterator<Item = K> + 'a, 
@@ -182,6 +276,50 @@ where
         })
     }
 
+    /// Iterates over provided ids, and returns an iterator over 
+    /// (id, usize), i.e. the identifier for each item 
+    /// and the bucketized estimate for that item in the raw global 
+    /// `CountMinSketch`
+    ///
+    /// # Example 
+    ///
+    /// ```
+    /// use decentrust::probabilistic::LightHonestPeer;
+    /// use decentrust::honest_peer::HonestPeer;
+    /// use buckets::bucketizers::range::RangeBucketizer;
+    /// use buckets::bucketize::BucketizeSingle;
+    /// use ordered_float::OrderedFloat;
+    /// use num_traits::Bounded;
+    ///
+    /// let mut hp: LightHonestPeer<String, OrderedFloat<f64>> = {
+    ///    LightHonestPeer::new_from_bounds(
+    ///        1f64,
+    ///        0.0001f64,
+    ///        3000f64,
+    ///        OrderedFloat::<f64>::min_value(),
+    ///        OrderedFloat::<f64>::max_value()
+    ///    )
+    /// };
+    ///
+    /// let node_ids = vec!["node_1".to_string(), "node_2".to_string(), "abcde".to_string()];
+    /// let ranges: Vec<(OrderedFloat<f64>, OrderedFloat<f64>)> = vec![
+    ///     (OrderedFloat::from(0.0), OrderedFloat::from(5.0)),
+    ///     (OrderedFloat::from(5.0), OrderedFloat::from(15.0)), 
+    ///     (OrderedFloat::from(15.0), OrderedFloat::from(30.0)),
+    ///     (OrderedFloat::from(30.0), OrderedFloat::<f64>::max_value())
+    /// ];
+    ///
+    /// let bucketizer = RangeBucketizer::new(ranges); 
+    ///
+    /// hp.update_global(&"node_1".to_string(), OrderedFloat::from(7.0));
+    /// hp.update_global(&"node_2".to_string(), OrderedFloat::from(3.0));
+    ///
+    /// let mut map = hp.bucketize_global(node_ids.iter().cloned(), bucketizer);
+    ///
+    /// assert_eq!(Some(("node_1".to_string(), 1)), map.next());
+    /// assert_eq!(Some(("node_2".to_string(), 0)), map.next());
+    /// assert_eq!(Some(("abcde".to_string(), 0)), map.next());
+    /// ```
     pub fn bucketize_global<'a, B>(
         &'a self, 
         node_ids: impl Iterator<Item = K> + 'a, 
@@ -198,6 +336,51 @@ where
         })
     }
 
+    /// Iterates over provided ids, and returns an iterator over 
+    /// (id, usize), i.e. the identifier for each item 
+    /// and the bucketized estimate for that item in the normalized global 
+    /// `CountMinSketch`
+    ///
+    /// # Example 
+    ///
+    /// ```
+    ///
+    /// use decentrust::probabilistic::LightHonestPeer;
+    /// use decentrust::honest_peer::HonestPeer;
+    /// use buckets::bucketizers::fw::FixedWidthBucketizer;
+    /// use buckets::bucketize::BucketizeSingle;
+    /// use buckets::into_usize::IntoUsize;
+    /// use ordered_float::OrderedFloat;
+    /// use num_traits::Bounded;
+    ///
+    /// let mut hp: LightHonestPeer<String, OrderedFloat<f64>> = {
+    ///    LightHonestPeer::new_from_bounds(
+    ///        1f64,
+    ///        0.0001f64,
+    ///        3000f64,
+    ///        OrderedFloat::<f64>::min_value(),
+    ///        OrderedFloat::<f64>::max_value()
+    ///    )
+    /// };
+    ///
+    /// let node_ids = vec!["node_1".to_string(), "node_2".to_string(), "abcde".to_string()];
+    ///
+    /// let bucketizer: FixedWidthBucketizer<OrderedFloat<f64>> = {
+    ///     FixedWidthBucketizer::<OrderedFloat<f64>>::new(
+    ///         OrderedFloat::from(0.05), OrderedFloat::from(0.0)
+    ///     ) 
+    /// };
+    ///
+    /// hp.update_global(&"node_1".to_string(), OrderedFloat::from(7.0));
+    /// hp.update_global(&"node_2".to_string(), OrderedFloat::from(3.0));
+    ///
+    /// let mut map = hp.bucketize_normalized_global(node_ids.iter().cloned(), bucketizer);
+    ///
+    /// assert_eq!(Some(("node_1".to_string(), 13)), map.next());
+    /// assert_eq!(Some(("node_2".to_string(), 5)), map.next());
+    /// assert_eq!(Some(("abcde".to_string(), 0)), map.next());
+    ///
+    /// ```
     pub fn bucketize_normalized_global<'a, B>(
         &'a self, 
         node_ids: impl Iterator<Item = K> + 'a, 
@@ -217,7 +400,7 @@ where
 
 impl<K, V> HonestPeer for LightHonestPeer<K, V> 
 where 
-    K: Eq + Hash + Clone,
+    K: Eq + Hash + Clone + Debug + ToString,
     V: AddAssign 
         + DivAssign 
         + SubAssign 
@@ -230,6 +413,7 @@ where
         + Bounded 
         + Ord 
         + Hash
+        + Debug
 {
     type Map = CountMinSketch<V>;
     type Key = K;


### PR DESCRIPTION
- [x] Bucketize raw local trust scores
- [x] Bucketize normalized local trust scores
- [x] Bucketize raw global trust scores
- [x] Bucketize normalized global trust scores
- [x] Provide doctests with examples and assertions for each method
    - [x] doctest with example and assertion statement for bucketized raw local
    - [x] doctest with example and assertion statement for bucketized normalized local
    - [x] doctest with example and assertion statement for bucketized raw global
    - [x] doctest with example and assertion statement for bucketized normalized global