### PR TITLE
Add methods to Bucketize PreciseHonestPeer values

### DIFF
--- a/src/honest_peer.rs
+++ b/src/honest_peer.rs
@@ -10,6 +10,7 @@ use std::ops::{
 
 use std::hash::Hash;
 
+use buckets::into_buckets::IntoBuckets;
 use num_traits::Bounded;
 
 /// A trait to implement a shared interface between a 

--- a/src/probabilistic.rs
+++ b/src/probabilistic.rs
@@ -396,6 +396,14 @@ where
 
         })
     }
+
+    pub fn get_width(&self) -> usize {
+        self.local_trust.get_width()
+    }
+
+    pub fn get_depth(&self) -> usize {
+        self.local_trust.get_depth()
+    }
 }
 
 impl<K, V> HonestPeer for LightHonestPeer<K, V> 


### PR DESCRIPTION
Also adds doctests for all bucketization methods, and adds a few other helper methods.

All that is left in this crate before being ready to be used is some unit tests to ensure values are handled correctly in all instances.